### PR TITLE
fix: allow maxQuantity to equal minQuantity for single-unit products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.0.3
+
+### Bug Fixes
+
+- Fixed assertion error when `maxQuantity` equals `minQuantity` (e.g., products limited to exactly 1 unit)
+  - Changed assertion from `maxQuantity > minQuantity` to `maxQuantity >= minQuantity` in both `CartStepperController` and `_CartStepperCore`
+  - This allows the stepper to properly handle edge cases where `maxQuantity == minQuantity`, automatically disabling the increment button when at max
+
 ## 2.0.2
 
 ### Bug Fixes

--- a/lib/src/_cart_stepper_core.dart
+++ b/lib/src/_cart_stepper_core.dart
@@ -140,7 +140,7 @@ class _CartStepperCore<T extends num> extends StatefulWidget {
     this.controller,
     this.quantityStream,
   })  : assert(minQuantity > 0, 'minQuantity must be > 0'),
-        assert(maxQuantity > minQuantity, 'maxQuantity must be > minQuantity'),
+        assert(maxQuantity >= minQuantity, 'maxQuantity must be >= minQuantity'),
         assert(step > 0, 'step must be > 0'),
         assert(quantity >= 0, 'quantity cannot be negative');
 

--- a/lib/src/cart_stepper_controller.dart
+++ b/lib/src/cart_stepper_controller.dart
@@ -109,7 +109,7 @@ class CartStepperController<T extends num> extends ChangeNotifier
     this.onMaxReached,
     this.onMinReached,
   })  : assert(minQuantity > 0, 'minQuantity must be > 0'),
-        assert(maxQuantity > minQuantity, 'maxQuantity must be > minQuantity'),
+        assert(maxQuantity >= minQuantity, 'maxQuantity must be >= minQuantity'),
         assert(step > 0, 'step must be > 0'),
         _quantity = initialQuantity,
         _isExpanded = initialQuantity > 0 {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: advance_cart_stepper
 description: "A customizable expandable cart quantity stepper widget for Flutter with async support, loading indicators, and theming."
-version: 2.0.2
+version: 2.0.3
 homepage: https://github.com/khaledsmq/advance_cart_stepper
 repository: https://github.com/khaledsmq/advance_cart_stepper
 issue_tracker: https://github.com/khaledsmq/advance_cart_stepper/issues


### PR DESCRIPTION
fix: support maxQuantity == minQuantity edge case