### PR TITLE
feat: add inline edit mode for manual input in CartStepper with configurable actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.1.0
+
+### Features
+
+- **Inline edit mode for manual input.** Tapping the quantity now turns the stepper into an editor in place: the number becomes a text field and the `-` / `+` buttons swap for cancel (`✕`) and confirm (`✓`) actions. Configure it via `CartStepperManualInputConfig`:
+  - `showEditActions` (default `true`) — set to `false` to keep `-` / `+` visible while editing
+  - `cancelIcon` / `confirmIcon` — icon overrides (default `Icons.close` / `Icons.check`)
+  - `editIconSize` — size of the cancel/confirm icons, defaults to the stepper's normal icon size
+  - `cancelIconColor` / `confirmIconColor` — default to the stepper's foreground color
+  - `cancelBackgroundColor` / `confirmBackgroundColor` — circular button backgrounds, transparent by default
+  - `submitOnFocusLost` (default `true`) — set to `false` so only the explicit confirm/cancel buttons leave edit mode
+
+### Bug Fixes
+
+- **Auto-collapse no longer fires while editing.** The collapse timer was being *restarted* when manual input began, so the stepper would collapse mid-keystroke. It is now suppressed until editing ends.
+- **Collapsing while editing no longer strands the stepper in edit mode.** Deleting the quantity (or any collapse to 0) left `_isEditingManually` set, so re-expanding showed an empty text field instead of the quantity. All collapse paths now exit edit mode.
+- **Tapping outside always leaves edit mode.** Previously, with `submitOnFocusLost: false`, an outside tap did nothing and the stepper stayed stuck as a text field. It now commits or cancels depending on that flag.
+
+### Changes
+
+- **Removed the decorative box around the quantity** that was drawn whenever `enableManualInput` was on. The number is still tappable, but renders plain — the switch to the inline editor is the affordance. Callers that relied on the tinted background + bottom border should supply their own wrapper.
+- The cancel/confirm circles are now inset from the button tap target so they never overflow the stepper's rounded edge; the full tap area stays hittable.
+
+## 2.0.3
+
+### Bug Fixes
+
+- Fixed assertion error when `maxQuantity` equals `minQuantity` (e.g., products limited to exactly 1 unit)
+  - Changed assertion from `maxQuantity > minQuantity` to `maxQuantity >= minQuantity` in both `CartStepperController` and `_CartStepperCore`
+  - This allows the stepper to properly handle edge cases where `maxQuantity == minQuantity`, automatically disabling the increment button when at max
+
 ## 2.0.2
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
   - `editIconSize` — size of the cancel/confirm icons, defaults to the stepper's normal icon size
   - `cancelIconColor` / `confirmIconColor` — default to the stepper's foreground color
   - `cancelBackgroundColor` / `confirmBackgroundColor` — circular button backgrounds, transparent by default
+  - `editBackgroundColor` / `editForegroundColor` — recolor the whole pill (and the number) while editing; default to the stepper's normal colors
   - `submitOnFocusLost` (default `true`) — set to `false` so only the explicit confirm/cancel buttons leave edit mode
 
 ### Bug Fixes

--- a/lib/src/_cart_stepper_builders.dart
+++ b/lib/src/_cart_stepper_builders.dart
@@ -439,31 +439,54 @@ mixin _CartStepperBuildersMixin<T extends num>
         widget.textDirection ?? Directionality.maybeOf(context);
     final isRtl = effectiveDirection == TextDirection.rtl;
 
-    final decrementButton = StepperButton(
-      icon: showDelete ? widget.deleteIcon : widget.decrementIcon,
-      iconSize: iconSize,
-      iconColor: _fgColor,
-      enabled: widget.enabled && canDec && allowInteraction,
-      onTap: () => _decrement(),
-      onLongPressStart: () => _startLongPress(false),
-      onLongPressEnd: _stopLongPress,
-      size: widget.size.buttonTapSize,
-      splashColor: _splColor,
-      highlightColor: _hlColor,
-    );
+    // While editing, the -/+ buttons become discard/commit actions so the
+    // stepper reads as an inline editor.
+    final editing = _isEditingManually &&
+        widget.enableManualInput &&
+        widget.manualInputConfig.showEditActions;
+    final editIconSize = widget.manualInputConfig.editIconSize ?? iconSize;
 
-    final incrementButton = StepperButton(
-      icon: widget.incrementIcon,
-      iconSize: iconSize,
-      iconColor: _fgColor,
-      enabled: widget.enabled && canInc && allowInteraction,
-      onTap: () => _increment(),
-      onLongPressStart: () => _startLongPress(true),
-      onLongPressEnd: _stopLongPress,
-      size: widget.size.buttonTapSize,
-      splashColor: _splColor,
-      highlightColor: _hlColor,
-    );
+    final decrementButton = editing
+        ? _buildEditActionButton(
+            icon: widget.manualInputConfig.cancelIcon,
+            iconSize: editIconSize,
+            iconColor: widget.manualInputConfig.cancelIconColor ?? _fgColor,
+            backgroundColor: widget.manualInputConfig.cancelBackgroundColor,
+            onTap: _cancelManualInput,
+          )
+        : StepperButton(
+            icon: showDelete ? widget.deleteIcon : widget.decrementIcon,
+            iconSize: iconSize,
+            iconColor: _fgColor,
+            enabled: widget.enabled && canDec && allowInteraction,
+            onTap: () => _decrement(),
+            onLongPressStart: () => _startLongPress(false),
+            onLongPressEnd: _stopLongPress,
+            size: widget.size.buttonTapSize,
+            splashColor: _splColor,
+            highlightColor: _hlColor,
+          );
+
+    final incrementButton = editing
+        ? _buildEditActionButton(
+            icon: widget.manualInputConfig.confirmIcon,
+            iconSize: editIconSize,
+            iconColor: widget.manualInputConfig.confirmIconColor ?? _fgColor,
+            backgroundColor: widget.manualInputConfig.confirmBackgroundColor,
+            onTap: () => _submitManualInput(_manualInputController?.text ?? ''),
+          )
+        : StepperButton(
+            icon: widget.incrementIcon,
+            iconSize: iconSize,
+            iconColor: _fgColor,
+            enabled: widget.enabled && canInc && allowInteraction,
+            onTap: () => _increment(),
+            onLongPressStart: () => _startLongPress(true),
+            onLongPressEnd: _stopLongPress,
+            size: widget.size.buttonTapSize,
+            splashColor: _splColor,
+            highlightColor: _hlColor,
+          );
 
     final quantityDisplay = Expanded(
       child: Center(
@@ -492,6 +515,46 @@ mixin _CartStepperBuildersMixin<T extends num>
         quantityDisplay,
         lastButton,
       ],
+    );
+  }
+
+  // ============================================================================
+  // Edit-mode Actions (cancel / confirm)
+  // ============================================================================
+  Widget _buildEditActionButton({
+    required IconData icon,
+    required double iconSize,
+    required Color iconColor,
+    required Color? backgroundColor,
+    required VoidCallback onTap,
+  }) {
+    final tapSize = widget.size.buttonTapSize;
+    // The painted circle is inset from the tap target so it never touches the
+    // stepper's rounded edge; the full tapSize stays hittable.
+    final circleSize = math.min(tapSize, widget.size.height - 8);
+
+    return SizedBox(
+      width: tapSize,
+      height: tapSize,
+      child: Center(
+        child: SizedBox(
+          width: circleSize,
+          height: circleSize,
+          child: Material(
+            color: backgroundColor ?? Colors.transparent,
+            shape: const CircleBorder(),
+            clipBehavior: Clip.antiAlias,
+            child: InkWell(
+              onTap: onTap,
+              splashColor: _splColor,
+              highlightColor: _hlColor,
+              child: Center(
+                child: Icon(icon, size: iconSize, color: iconColor),
+              ),
+            ),
+          ),
+        ),
+      ),
     );
   }
 
@@ -529,24 +592,13 @@ mixin _CartStepperBuildersMixin<T extends num>
       formatter: widget.quantityFormatter,
     );
 
+    // Tappable but undecorated — the stepper switches to its inline editor on
+    // tap, so the number needs no extra affordance chrome.
     if (widget.enableManualInput && widget.enabled && !_isLoading) {
       return GestureDetector(
         onTap: _startManualInput,
         behavior: HitTestBehavior.opaque,
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-          decoration: BoxDecoration(
-            color: _fgColor.withValues(alpha: 0.1),
-            borderRadius: BorderRadius.circular(4),
-            border: Border(
-              bottom: BorderSide(
-                color: _fgColor.withValues(alpha: 0.5),
-                width: 1.5,
-              ),
-            ),
-          ),
-          child: counter,
-        ),
+        child: counter,
       );
     }
 
@@ -563,28 +615,20 @@ mixin _CartStepperBuildersMixin<T extends num>
       fontWeight: widget.style.fontWeight,
     ).merge(widget.style.textStyle);
 
+    // `filled: false` is explicit so an ambient InputDecorationTheme cannot
+    // paint a background behind the field — it must blend with the stepper.
     final decoration = widget.manualInputDecoration ??
-        InputDecoration(
+        const InputDecoration(
           isDense: true,
-          contentPadding:
-              const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          filled: false,
+          contentPadding: EdgeInsets.symmetric(horizontal: 8, vertical: 4),
           border: InputBorder.none,
           enabledBorder: InputBorder.none,
           focusedBorder: InputBorder.none,
         );
 
-    return Container(
+    return SizedBox(
       width: widget.size.expandedWidth * 0.35,
-      decoration: BoxDecoration(
-        color: _fgColor.withValues(alpha: 0.15),
-        borderRadius: BorderRadius.circular(4),
-        border: Border(
-          bottom: BorderSide(
-            color: _fgColor,
-            width: 2,
-          ),
-        ),
-      ),
       child: TextField(
         controller: _manualInputController,
         focusNode: _manualInputFocusNode,
@@ -601,8 +645,14 @@ mixin _CartStepperBuildersMixin<T extends num>
         ],
         onSubmitted: _submitManualInput,
         onTapOutside: (_) {
-          if (_isEditingManually) {
+          if (!_isEditingManually) return;
+          // Tapping away either commits the value or discards it, but either
+          // way it must leave edit mode — otherwise the stepper stays stuck
+          // showing a text field.
+          if (widget.manualInputConfig.submitOnFocusLost) {
             _submitManualInput(_manualInputController?.text ?? '');
+          } else {
+            _cancelManualInput();
           }
         },
       ),

--- a/lib/src/_cart_stepper_builders.dart
+++ b/lib/src/_cart_stepper_builders.dart
@@ -441,9 +441,7 @@ mixin _CartStepperBuildersMixin<T extends num>
 
     // While editing, the -/+ buttons become discard/commit actions so the
     // stepper reads as an inline editor.
-    final editing = _isEditingManually &&
-        widget.enableManualInput &&
-        widget.manualInputConfig.showEditActions;
+    final editing = _editing;
     final editIconSize = widget.manualInputConfig.editIconSize ?? iconSize;
 
     final decrementButton = editing

--- a/lib/src/_cart_stepper_core.dart
+++ b/lib/src/_cart_stepper_core.dart
@@ -62,6 +62,9 @@ class _CartStepperCore<T extends num> extends StatefulWidget {
   final ValueChanged<num>? onManualInputSubmitted;
   final Widget Function(BuildContext, num, ValueChanged<String>, VoidCallback)?
       manualInputBuilder;
+
+  /// Edit-mode presentation (cancel/confirm actions) for manual input.
+  final CartStepperManualInputConfig manualInputConfig;
   final CollapsedButtonBuilder? collapsedBuilder;
   final double? collapsedWidth;
   final double? collapsedHeight;
@@ -128,6 +131,7 @@ class _CartStepperCore<T extends num> extends StatefulWidget {
     this.manualInputDecoration,
     this.onManualInputSubmitted,
     this.manualInputBuilder,
+    this.manualInputConfig = const CartStepperManualInputConfig(),
     this.collapsedBuilder,
     this.collapsedWidth,
     this.collapsedHeight,
@@ -140,7 +144,8 @@ class _CartStepperCore<T extends num> extends StatefulWidget {
     this.controller,
     this.quantityStream,
   })  : assert(minQuantity > 0, 'minQuantity must be > 0'),
-        assert(maxQuantity > minQuantity, 'maxQuantity must be > minQuantity'),
+        assert(
+            maxQuantity >= minQuantity, 'maxQuantity must be >= minQuantity'),
         assert(step > 0, 'step must be > 0'),
         assert(quantity >= 0, 'quantity cannot be negative');
 

--- a/lib/src/_cart_stepper_core.dart
+++ b/lib/src/_cart_stepper_core.dart
@@ -309,9 +309,20 @@ abstract class _CartStepperStateBase<T extends num>
   // ============================================================================
   // Color Accessors
   // ============================================================================
-  Color get _bgColor => _backgroundColor!;
 
-  Color get _fgColor => _foregroundColor!;
+  /// Whether the inline editor is currently active.
+  bool get _editing =>
+      _isEditingManually &&
+      widget.enableManualInput &&
+      widget.manualInputConfig.showEditActions;
+
+  Color get _bgColor =>
+      (_editing ? widget.manualInputConfig.editBackgroundColor : null) ??
+      _backgroundColor!;
+
+  Color get _fgColor =>
+      (_editing ? widget.manualInputConfig.editForegroundColor : null) ??
+      _foregroundColor!;
 
   Color get _bdColor => _borderColor!;
 

--- a/lib/src/_cart_stepper_facades.dart
+++ b/lib/src/_cart_stepper_facades.dart
@@ -515,6 +515,7 @@ class AsyncCartStepper<T extends num> extends StatelessWidget {
       manualInputDecoration: manualInput?.decoration,
       onManualInputSubmitted: manualInput?.onSubmitted,
       manualInputBuilder: manualInput?.builder,
+      manualInputConfig: manualInput ?? const CartStepperManualInputConfig(),
       // Error handling
       onError: onError,
       errorBuilder: errorBuilder,

--- a/lib/src/_cart_stepper_operations.dart
+++ b/lib/src/_cart_stepper_operations.dart
@@ -22,6 +22,7 @@ mixin _CartStepperOperationsMixin<T extends num> on _CartStepperStateBase<T> {
     if (newQty == 0) {
       if (_isExpanded && widget.autoCollapse) {
         _isExpanded = false;
+        _exitEditMode();
         _controller.reverse();
         _collapseTimer?.cancel();
       }
@@ -35,15 +36,30 @@ mixin _CartStepperOperationsMixin<T extends num> on _CartStepperStateBase<T> {
     }
   }
 
+  /// Leaves manual-input mode without committing, so a collapsed stepper never
+  /// re-expands into a stale (and empty) text field instead of the quantity.
+  void _exitEditMode() {
+    if (!_isEditingManually) return;
+    _isEditingManually = false;
+    _isSubmittingManualInput = false;
+    _manualInputFocusNode?.unfocus();
+  }
+
   // ============================================================================
   // Timer Management
   // ============================================================================
   void _resetCollapseTimer() {
     _collapseTimer?.cancel();
+    // Never auto-collapse while the user is typing a quantity — they'd lose
+    // the edit mid-keystroke. The timer resumes once editing ends.
+    if (_isEditingManually) return;
     if (widget.autoCollapseDelay != null && _isExpanded) {
       _collapseTimer = Timer(widget.autoCollapseDelay!, () {
-        if (!mounted || !_isExpanded) return;
-        setState(() => _isExpanded = false);
+        if (!mounted || !_isExpanded || _isEditingManually) return;
+        setState(() {
+          _isExpanded = false;
+          _exitEditMode();
+        });
         _controller.reverse();
       });
     }
@@ -151,6 +167,7 @@ mixin _CartStepperOperationsMixin<T extends num> on _CartStepperStateBase<T> {
 
   void _onManualInputFocusChange() {
     if (!mounted) return;
+    if (!widget.manualInputConfig.submitOnFocusLost) return;
     if (_manualInputFocusNode != null &&
         !_manualInputFocusNode!.hasFocus &&
         _isEditingManually) {

--- a/lib/src/cart_stepper_config.dart
+++ b/lib/src/cart_stepper_config.dart
@@ -806,6 +806,44 @@ class CartStepperManualInputConfig {
     VoidCallback onCancel,
   )? builder;
 
+  /// Whether entering manual input swaps the decrement/increment buttons for
+  /// cancel (`✕`) and confirm (`✓`) actions.
+  ///
+  /// When `true` (the default), the stepper becomes an inline editor: the
+  /// quantity turns into a text field and the two side buttons commit or
+  /// discard the typed value. When `false`, `-`/`+` remain visible.
+  final bool showEditActions;
+
+  /// Icon for the cancel (discard) action shown while editing.
+  final IconData cancelIcon;
+
+  /// Icon for the confirm (commit) action shown while editing.
+  final IconData confirmIcon;
+
+  /// Size of the cancel/confirm icons. Falls back to the stepper's normal
+  /// icon size when null.
+  final double? editIconSize;
+
+  /// Icon color of the cancel action. Falls back to the stepper's foreground
+  /// color when null.
+  final Color? cancelIconColor;
+
+  /// Icon color of the confirm action. Falls back to the stepper's foreground
+  /// color when null.
+  final Color? confirmIconColor;
+
+  /// Circular background behind the cancel action. Transparent when null.
+  final Color? cancelBackgroundColor;
+
+  /// Circular background behind the confirm action. Transparent when null.
+  final Color? confirmBackgroundColor;
+
+  /// Whether losing focus (e.g. tapping outside) commits the typed value.
+  ///
+  /// Defaults to `true`. Set to `false` when the explicit confirm/cancel
+  /// buttons should be the only way to leave edit mode.
+  final bool submitOnFocusLost;
+
   /// Creates a manual input configuration.
   const CartStepperManualInputConfig({
     this.enabled = true,
@@ -813,6 +851,15 @@ class CartStepperManualInputConfig {
     this.decoration,
     this.onSubmitted,
     this.builder,
+    this.showEditActions = true,
+    this.cancelIcon = Icons.close,
+    this.confirmIcon = Icons.check,
+    this.editIconSize,
+    this.cancelIconColor,
+    this.confirmIconColor,
+    this.cancelBackgroundColor,
+    this.confirmBackgroundColor,
+    this.submitOnFocusLost = true,
   });
 
   /// Creates a copy of this configuration with the given fields replaced.
@@ -827,6 +874,15 @@ class CartStepperManualInputConfig {
       ValueChanged<String> onSubmit,
       VoidCallback onCancel,
     )? builder,
+    bool? showEditActions,
+    IconData? cancelIcon,
+    IconData? confirmIcon,
+    double? editIconSize,
+    Color? cancelIconColor,
+    Color? confirmIconColor,
+    Color? cancelBackgroundColor,
+    Color? confirmBackgroundColor,
+    bool? submitOnFocusLost,
   }) {
     return CartStepperManualInputConfig(
       enabled: enabled ?? this.enabled,
@@ -834,6 +890,17 @@ class CartStepperManualInputConfig {
       decoration: decoration ?? this.decoration,
       onSubmitted: onSubmitted ?? this.onSubmitted,
       builder: builder ?? this.builder,
+      showEditActions: showEditActions ?? this.showEditActions,
+      cancelIcon: cancelIcon ?? this.cancelIcon,
+      confirmIcon: confirmIcon ?? this.confirmIcon,
+      editIconSize: editIconSize ?? this.editIconSize,
+      cancelIconColor: cancelIconColor ?? this.cancelIconColor,
+      confirmIconColor: confirmIconColor ?? this.confirmIconColor,
+      cancelBackgroundColor:
+          cancelBackgroundColor ?? this.cancelBackgroundColor,
+      confirmBackgroundColor:
+          confirmBackgroundColor ?? this.confirmBackgroundColor,
+      submitOnFocusLost: submitOnFocusLost ?? this.submitOnFocusLost,
     );
   }
 
@@ -845,7 +912,16 @@ class CartStepperManualInputConfig {
         other.keyboardType == keyboardType &&
         other.decoration == decoration &&
         other.onSubmitted == onSubmitted &&
-        other.builder == builder;
+        other.builder == builder &&
+        other.showEditActions == showEditActions &&
+        other.cancelIcon == cancelIcon &&
+        other.confirmIcon == confirmIcon &&
+        other.editIconSize == editIconSize &&
+        other.cancelIconColor == cancelIconColor &&
+        other.confirmIconColor == confirmIconColor &&
+        other.cancelBackgroundColor == cancelBackgroundColor &&
+        other.confirmBackgroundColor == confirmBackgroundColor &&
+        other.submitOnFocusLost == submitOnFocusLost;
   }
 
   @override
@@ -855,6 +931,15 @@ class CartStepperManualInputConfig {
         decoration,
         onSubmitted,
         builder,
+        showEditActions,
+        cancelIcon,
+        confirmIcon,
+        editIconSize,
+        cancelIconColor,
+        confirmIconColor,
+        cancelBackgroundColor,
+        confirmBackgroundColor,
+        submitOnFocusLost,
       );
 }
 

--- a/lib/src/cart_stepper_config.dart
+++ b/lib/src/cart_stepper_config.dart
@@ -838,6 +838,14 @@ class CartStepperManualInputConfig {
   /// Circular background behind the confirm action. Transparent when null.
   final Color? confirmBackgroundColor;
 
+  /// Pill background of the whole stepper while editing. Falls back to the
+  /// stepper's normal background color when null.
+  final Color? editBackgroundColor;
+
+  /// Foreground (number + cursor) color while editing. Falls back to the
+  /// stepper's normal foreground color when null.
+  final Color? editForegroundColor;
+
   /// Whether losing focus (e.g. tapping outside) commits the typed value.
   ///
   /// Defaults to `true`. Set to `false` when the explicit confirm/cancel
@@ -859,6 +867,8 @@ class CartStepperManualInputConfig {
     this.confirmIconColor,
     this.cancelBackgroundColor,
     this.confirmBackgroundColor,
+    this.editBackgroundColor,
+    this.editForegroundColor,
     this.submitOnFocusLost = true,
   });
 
@@ -882,6 +892,8 @@ class CartStepperManualInputConfig {
     Color? confirmIconColor,
     Color? cancelBackgroundColor,
     Color? confirmBackgroundColor,
+    Color? editBackgroundColor,
+    Color? editForegroundColor,
     bool? submitOnFocusLost,
   }) {
     return CartStepperManualInputConfig(
@@ -900,6 +912,8 @@ class CartStepperManualInputConfig {
           cancelBackgroundColor ?? this.cancelBackgroundColor,
       confirmBackgroundColor:
           confirmBackgroundColor ?? this.confirmBackgroundColor,
+      editBackgroundColor: editBackgroundColor ?? this.editBackgroundColor,
+      editForegroundColor: editForegroundColor ?? this.editForegroundColor,
       submitOnFocusLost: submitOnFocusLost ?? this.submitOnFocusLost,
     );
   }
@@ -921,6 +935,8 @@ class CartStepperManualInputConfig {
         other.confirmIconColor == confirmIconColor &&
         other.cancelBackgroundColor == cancelBackgroundColor &&
         other.confirmBackgroundColor == confirmBackgroundColor &&
+        other.editBackgroundColor == editBackgroundColor &&
+        other.editForegroundColor == editForegroundColor &&
         other.submitOnFocusLost == submitOnFocusLost;
   }
 
@@ -939,6 +955,8 @@ class CartStepperManualInputConfig {
         confirmIconColor,
         cancelBackgroundColor,
         confirmBackgroundColor,
+        editBackgroundColor,
+        editForegroundColor,
         submitOnFocusLost,
       );
 }

--- a/lib/src/cart_stepper_controller.dart
+++ b/lib/src/cart_stepper_controller.dart
@@ -109,7 +109,8 @@ class CartStepperController<T extends num> extends ChangeNotifier
     this.onMaxReached,
     this.onMinReached,
   })  : assert(minQuantity > 0, 'minQuantity must be > 0'),
-        assert(maxQuantity > minQuantity, 'maxQuantity must be > minQuantity'),
+        assert(
+            maxQuantity >= minQuantity, 'maxQuantity must be >= minQuantity'),
         assert(step > 0, 'step must be > 0'),
         _quantity = initialQuantity,
         _isExpanded = initialQuantity > 0 {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: advance_cart_stepper
 description: "A customizable expandable cart quantity stepper widget for Flutter with async support, loading indicators, and theming."
-version: 2.0.2
+version: 2.1.0
 homepage: https://github.com/khaledsmq/advance_cart_stepper
 repository: https://github.com/khaledsmq/advance_cart_stepper
 issue_tracker: https://github.com/khaledsmq/advance_cart_stepper/issues


### PR DESCRIPTION
- add inline edit mode for manual input in CartStepper with configurable actions