### PR TITLE
chore: release v2.1.1 with bug fixes and new features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.1.1
+
+### Bug Fixes
+
+- **iOS confirm/cancel in inline edit mode now apply correctly.** Tapping ✓ or ✕ while the keyboard was open only dismissed the keyboard and left the quantity unchanged. The edit-action buttons are now wrapped in a `TextFieldTapRegion` (and guarded against focus-loss races) so the tap reaches confirm/cancel instead of being treated as "tap outside".
+- **Quantity tap target for inline edit is larger.** Opening edit previously required hitting the digit glyphs; the whole middle area between −/+ is now tappable.
+
 ## 2.1.0
 
 ### Features

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,47 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+ios/
+test/
+.atom/
+.build/
+.buildlog/
+.history
+.svn/
+.swiftpm/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+**/ios/Flutter/.last_build_id
+.dart_tool/
+.flutter-plugins-dependencies
+.pub-cache/
+.pub/
+/build/
+/coverage/
+
+# Symbolication related
+app.*.symbols
+
+# Obfuscation related
+app.*.map.json
+
+# Android Studio will place build artifacts here
+/android/app/debug
+/android/app/profile
+/android/app/release

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,0 +1,28 @@
+# This file configures the analyzer, which statically analyzes Dart code to
+# check for errors, warnings, and lints.
+#
+# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
+# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
+# invoked from the command line by running `flutter analyze`.
+
+# The following line activates a set of recommended lints for Flutter apps,
+# packages, and plugins designed to encourage good coding practices.
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  # The lint rules applied to this project can be customized in the
+  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
+  # included above or to enable additional rules. A list of all available lints
+  # and their documentation is published at https://dart.dev/lints.
+  #
+  # Instead of disabling a lint rule for the entire project in the
+  # section below, it can also be suppressed for a single line of code
+  # or a specific dart file by using the `// ignore: name_of_lint` and
+  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
+  # producing the lint.
+  rules:
+    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
+    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -17,12 +17,14 @@ class CartStepperExampleApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFFD84315)),
         useMaterial3: true,
       ),
-      darkTheme: ThemeData.dark(useMaterial3: true).copyWith(
+      darkTheme: ThemeData(
         colorScheme: ColorScheme.fromSeed(
           seedColor: const Color(0xFFD84315),
           brightness: Brightness.dark,
         ),
+        useMaterial3: true,
       ),
+      themeMode: ThemeMode.system,
       home: const CartStepperDemo(),
     );
   }
@@ -292,7 +294,7 @@ class _BasicsTabState extends State<_BasicsTab>
               'Fully custom widget via collapsedBuilder',
               style: TextStyle(
                 fontSize: 12,
-                color: Colors.grey[600],
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
                 fontStyle: FontStyle.italic,
               ),
             ),
@@ -318,7 +320,7 @@ class _BasicsTabState extends State<_BasicsTab>
               'Tap + to add, use -/+ to adjust, trash to remove',
               style: TextStyle(
                 fontSize: 12,
-                color: Colors.grey[600],
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
                 fontStyle: FontStyle.italic,
               ),
             ),
@@ -679,7 +681,7 @@ class _AsyncTabState extends State<_AsyncTab>
               'Notice: quantity updates instantly while loading',
               style: TextStyle(
                 fontSize: 12,
-                color: Colors.grey[600],
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
                 fontStyle: FontStyle.italic,
               ),
             ),
@@ -839,7 +841,7 @@ class _AsyncTabState extends State<_AsyncTab>
               'Try incrementing past 5 to trigger an error',
               style: TextStyle(
                 fontSize: 12,
-                color: Colors.grey[600],
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
                 fontStyle: FontStyle.italic,
               ),
             ),
@@ -986,10 +988,12 @@ class _AdvancedTabState extends State<_AdvancedTab>
   // Validation
   int _validationQty = 2;
 
-  // Manual Input
+  // Manual Input / Inline Edit
   int _manualInputQty = 5;
+  int _inlineEditStyledQty = 8;
   int _manualInputLargeQty = 25;
   int _customInputBuilderQty = 10;
+  int _noEditActionsQty = 4;
 
   // v2.0 new features
   double _decimalQty = 1.5;
@@ -1110,7 +1114,7 @@ class _AdvancedTabState extends State<_AdvancedTab>
               'Long-press and hold +/- buttons to see the difference',
               style: TextStyle(
                 fontSize: 12,
-                color: Colors.grey[600],
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
                 fontStyle: FontStyle.italic,
               ),
             ),
@@ -1278,7 +1282,7 @@ class _AdvancedTabState extends State<_AdvancedTab>
               'Wait 3 seconds to see it collapse to badge view',
               style: TextStyle(
                 fontSize: 12,
-                color: Colors.grey[600],
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
                 fontStyle: FontStyle.italic,
               ),
             ),
@@ -1363,7 +1367,7 @@ class _AdvancedTabState extends State<_AdvancedTab>
               'CartStepper<double> with step: 0.5',
               style: TextStyle(
                 fontSize: 12,
-                color: Colors.grey[600],
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
                 fontStyle: FontStyle.italic,
               ),
             ),
@@ -1399,11 +1403,11 @@ class _AdvancedTabState extends State<_AdvancedTab>
         const SizedBox(height: 24),
         _buildSection(
           context,
-          'Manual Input',
-          'Tap on the quantity to type a value directly',
+          'Inline Edit Mode',
+          'Tap the quantity to type a value — −/+ become ✕/✓',
           [
             _buildRow(
-              'Tap to edit (max: 99)',
+              'Default inline edit',
               AsyncCartStepper(
                 quantity: _manualInputQty,
                 manualInputConfig: CartStepperManualInputConfig(
@@ -1411,7 +1415,7 @@ class _AdvancedTabState extends State<_AdvancedTab>
                   onSubmitted: (qty) {
                     ScaffoldMessenger.of(context).showSnackBar(
                       SnackBar(
-                        content: Text('Manually set to $qty'),
+                        content: Text('Confirmed: $qty'),
                         duration: const Duration(seconds: 1),
                       ),
                     );
@@ -1424,16 +1428,57 @@ class _AdvancedTabState extends State<_AdvancedTab>
             ),
             const SizedBox(height: 8),
             Text(
-              'Tap the number in the stepper to open keyboard input',
+              'Tap the number → type → ✓ to commit or ✕ to discard',
               style: TextStyle(
                 fontSize: 12,
-                color: Colors.grey[600],
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
                 fontStyle: FontStyle.italic,
               ),
             ),
             const SizedBox(height: 16),
             _buildRow(
-              'Large size with manual input',
+              'Styled edit actions',
+              AsyncCartStepper(
+                quantity: _inlineEditStyledQty,
+                style: const CartStepperStyle(
+                  backgroundColor: Color(0xFF1565C0),
+                  foregroundColor: Colors.white,
+                ),
+                manualInputConfig: CartStepperManualInputConfig(
+                  enabled: true,
+                  editBackgroundColor: const Color(0xFF0D47A1),
+                  editForegroundColor: Colors.white,
+                  cancelBackgroundColor: Colors.red.shade700,
+                  confirmBackgroundColor: Colors.green.shade600,
+                  cancelIconColor: Colors.white,
+                  confirmIconColor: Colors.white,
+                  submitOnFocusLost: false,
+                  onSubmitted: (qty) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text('Saved: $qty'),
+                        duration: const Duration(seconds: 1),
+                      ),
+                    );
+                  },
+                ),
+                onQuantityChanged: (qty) =>
+                    setState(() => _inlineEditStyledQty = qty),
+                onRemove: () => setState(() => _inlineEditStyledQty = 0),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Colored cancel/confirm + edit pill; only ✓/✕ leave edit mode',
+              style: TextStyle(
+                fontSize: 12,
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+            const SizedBox(height: 16),
+            _buildRow(
+              'Large size',
               AsyncCartStepper(
                 quantity: _manualInputLargeQty,
                 size: CartStepperSize.large,
@@ -1448,52 +1493,84 @@ class _AdvancedTabState extends State<_AdvancedTab>
             ),
             const SizedBox(height: 16),
             _buildRow(
+              'Without edit actions (−/+ stay)',
+              AsyncCartStepper(
+                quantity: _noEditActionsQty,
+                manualInputConfig: const CartStepperManualInputConfig(
+                  enabled: true,
+                  showEditActions: false,
+                ),
+                onQuantityChanged: (qty) =>
+                    setState(() => _noEditActionsQty = qty),
+                onRemove: () => setState(() => _noEditActionsQty = 0),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Keyboard still works; −/+ remain visible while typing',
+              style: TextStyle(
+                fontSize: 12,
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+            const SizedBox(height: 16),
+            _buildRow(
               'Custom input builder',
               AsyncCartStepper(
                 quantity: _customInputBuilderQty,
                 maxQuantity: 50,
                 manualInputConfig: CartStepperManualInputConfig(
                   enabled: true,
+                  showEditActions: false,
                   builder: (context, currentValue, onSubmit, onCancel) {
                     final controller =
                         TextEditingController(text: currentValue.toString());
-                    return Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 8, vertical: 4),
-                      decoration: BoxDecoration(
-                        color: Colors.white.withValues(alpha: 0.2),
-                        borderRadius: BorderRadius.circular(8),
-                        border: Border.all(color: Colors.white, width: 2),
-                      ),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          SizedBox(
-                            width: 40,
-                            child: TextField(
-                              controller: controller,
-                              keyboardType: TextInputType.number,
-                              textAlign: TextAlign.center,
-                              style: const TextStyle(
-                                color: Colors.white,
-                                fontSize: 14,
-                                fontWeight: FontWeight.bold,
+                    return TextFieldTapRegion(
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 8, vertical: 4),
+                        decoration: BoxDecoration(
+                          color: Colors.white.withValues(alpha: 0.2),
+                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(color: Colors.white, width: 2),
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            SizedBox(
+                              width: 40,
+                              child: TextField(
+                                controller: controller,
+                                keyboardType: TextInputType.number,
+                                textAlign: TextAlign.center,
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                                decoration: const InputDecoration(
+                                  isDense: true,
+                                  contentPadding: EdgeInsets.zero,
+                                  border: InputBorder.none,
+                                ),
+                                autofocus: true,
+                                onSubmitted: onSubmit,
                               ),
-                              decoration: const InputDecoration(
-                                isDense: true,
-                                contentPadding: EdgeInsets.zero,
-                                border: InputBorder.none,
-                              ),
-                              autofocus: true,
-                              onSubmitted: onSubmit,
                             ),
-                          ),
-                          GestureDetector(
-                            onTap: () => onSubmit(controller.text),
-                            child: const Icon(Icons.check,
-                                color: Colors.white, size: 16),
-                          ),
-                        ],
+                            GestureDetector(
+                              onTap: () => onSubmit(controller.text),
+                              child: const Icon(Icons.check,
+                                  color: Colors.white, size: 16),
+                            ),
+                            const SizedBox(width: 4),
+                            GestureDetector(
+                              onTap: onCancel,
+                              child: const Icon(Icons.close,
+                                  color: Colors.white70, size: 16),
+                            ),
+                          ],
+                        ),
                       ),
                     );
                   },
@@ -1505,10 +1582,10 @@ class _AdvancedTabState extends State<_AdvancedTab>
             ),
             const SizedBox(height: 8),
             Text(
-              'Custom builder with a confirm button',
+              'Fully custom field UI via manualInputConfig.builder',
               style: TextStyle(
                 fontSize: 12,
-                color: Colors.grey[600],
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
                 fontStyle: FontStyle.italic,
               ),
             ),
@@ -1544,7 +1621,7 @@ class _AdvancedTabState extends State<_AdvancedTab>
               'Notice the increment/decrement buttons are swapped in RTL',
               style: TextStyle(
                 fontSize: 12,
-                color: Colors.grey[600],
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
                 fontStyle: FontStyle.italic,
               ),
             ),
@@ -1573,7 +1650,7 @@ class _AdvancedTabState extends State<_AdvancedTab>
               'Delete an item and watch the undo indicator appear',
               style: TextStyle(
                 fontSize: 12,
-                color: Colors.grey[600],
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
                 fontStyle: FontStyle.italic,
               ),
             ),
@@ -1634,7 +1711,7 @@ class _AdvancedTabState extends State<_AdvancedTab>
               'Tap +/- to see the change type reported above',
               style: TextStyle(
                 fontSize: 12,
-                color: Colors.grey[600],
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
                 fontStyle: FontStyle.italic,
               ),
             ),
@@ -1726,7 +1803,7 @@ class _AdvancedTabState extends State<_AdvancedTab>
               'Tap + to see scale transition instead of width animation',
               style: TextStyle(
                 fontSize: 12,
-                color: Colors.grey[600],
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
                 fontStyle: FontStyle.italic,
               ),
             ),
@@ -1867,7 +1944,7 @@ class _ComponentsTabState extends State<_ComponentsTab>
             Container(
               padding: const EdgeInsets.all(8),
               decoration: BoxDecoration(
-                color: Colors.grey.shade100,
+                color: Theme.of(context).colorScheme.surfaceContainerHighest,
                 borderRadius: BorderRadius.circular(8),
               ),
               child: Text(
@@ -1875,7 +1952,11 @@ class _ComponentsTabState extends State<_ComponentsTab>
                 'canDecrement: ${_controller.canDecrement}\n'
                 'isAtMin: ${_controller.isAtMin}\n'
                 'isAtMax: ${_controller.isAtMax}',
-                style: const TextStyle(fontSize: 12, fontFamily: 'monospace'),
+                style: TextStyle(
+                  fontSize: 12,
+                  fontFamily: 'monospace',
+                  color: Theme.of(context).colorScheme.onSurface,
+                ),
               ),
             ),
           ],
@@ -1993,7 +2074,7 @@ class _ComponentsTabState extends State<_ComponentsTab>
               'Tap the monitor tile to see onTap callback',
               style: TextStyle(
                 fontSize: 12,
-                color: Colors.grey[600],
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
                 fontStyle: FontStyle.italic,
               ),
             ),
@@ -2035,7 +2116,7 @@ class _ComponentsTabState extends State<_ComponentsTab>
               'CartProductTile<double> with step: 0.25 for weight-based pricing',
               style: TextStyle(
                 fontSize: 12,
-                color: Colors.grey[600],
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
                 fontStyle: FontStyle.italic,
               ),
             ),
@@ -2182,7 +2263,7 @@ class _ComponentsTabState extends State<_ComponentsTab>
               'CartStepperSelectionMode.single',
               style: TextStyle(
                 fontSize: 12,
-                color: Colors.grey[600],
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
                 fontStyle: FontStyle.italic,
               ),
             ),
@@ -2548,7 +2629,7 @@ class _RealWorldTabState extends State<_RealWorldTab>
                     Text(
                       '$_totalItems items',
                       style: theme.textTheme.bodySmall?.copyWith(
-                        color: Colors.grey[600],
+                        color: theme.colorScheme.onSurfaceVariant,
                       ),
                     ),
                   ],
@@ -2560,7 +2641,7 @@ class _RealWorldTabState extends State<_RealWorldTab>
                   Text(
                     'Total',
                     style: theme.textTheme.bodySmall?.copyWith(
-                      color: Colors.grey[600],
+                      color: theme.colorScheme.onSurfaceVariant,
                     ),
                   ),
                   Text(
@@ -2589,12 +2670,12 @@ class _RealWorldTabState extends State<_RealWorldTab>
                   width: 64,
                   height: 64,
                   decoration: BoxDecoration(
-                    color: Colors.grey[200],
+                    color: theme.colorScheme.surfaceContainerHighest,
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Icon(
                     product.image,
-                    color: Colors.grey[600],
+                    color: theme.colorScheme.onSurfaceVariant,
                     size: 32,
                   ),
                 ),
@@ -2624,14 +2705,22 @@ class _RealWorldTabState extends State<_RealWorldTab>
         Container(
           padding: const EdgeInsets.all(16),
           decoration: BoxDecoration(
-            color: Colors.green.shade50,
+            color: theme.brightness == Brightness.dark
+                ? Colors.green.shade900.withValues(alpha: 0.35)
+                : Colors.green.shade50,
             border: Border(
               bottom: BorderSide(color: theme.dividerColor),
             ),
           ),
           child: Row(
             children: [
-              Icon(Icons.storefront, size: 32, color: Colors.green.shade700),
+              Icon(
+                Icons.storefront,
+                size: 32,
+                color: theme.brightness == Brightness.dark
+                    ? Colors.green.shade300
+                    : Colors.green.shade700,
+              ),
               const SizedBox(width: 12),
               Expanded(
                 child: Column(
@@ -2646,7 +2735,7 @@ class _RealWorldTabState extends State<_RealWorldTab>
                     Text(
                       'Tap + to add items to your basket',
                       style: theme.textTheme.bodySmall?.copyWith(
-                        color: Colors.grey[600],
+                        color: theme.colorScheme.onSurfaceVariant,
                       ),
                     ),
                   ],
@@ -2811,10 +2900,11 @@ class _ViewToggleButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
     return Material(
       color: isSelected
-          ? theme.colorScheme.primaryContainer
-          : Colors.grey.shade100,
+          ? scheme.primaryContainer
+          : scheme.surfaceContainerHighest,
       borderRadius: BorderRadius.circular(12),
       child: InkWell(
         onTap: onTap,
@@ -2832,16 +2922,17 @@ class _ViewToggleButton extends StatelessWidget {
                     icon,
                     size: 20,
                     color: isSelected
-                        ? theme.colorScheme.primary
-                        : Colors.grey[600],
+                        ? scheme.primary
+                        : scheme.onSurfaceVariant,
                   ),
                 )
               else
                 Icon(
                   icon,
                   size: 20,
-                  color:
-                      isSelected ? theme.colorScheme.primary : Colors.grey[600],
+                  color: isSelected
+                      ? scheme.primary
+                      : scheme.onSurfaceVariant,
                 ),
               const SizedBox(width: 8),
               Flexible(
@@ -2852,8 +2943,8 @@ class _ViewToggleButton extends StatelessWidget {
                     fontWeight:
                         isSelected ? FontWeight.w600 : FontWeight.normal,
                     color: isSelected
-                        ? theme.colorScheme.primary
-                        : Colors.grey[600],
+                        ? scheme.primary
+                        : scheme.onSurfaceVariant,
                   ),
                   overflow: TextOverflow.ellipsis,
                 ),
@@ -2875,6 +2966,7 @@ Widget _buildSection(
   String description,
   List<Widget> children,
 ) {
+  final scheme = Theme.of(context).colorScheme;
   return Column(
     crossAxisAlignment: CrossAxisAlignment.start,
     children: [
@@ -2888,18 +2980,27 @@ Widget _buildSection(
       Text(
         description,
         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              color: Colors.grey[600],
+              color: scheme.onSurfaceVariant,
             ),
       ),
       const SizedBox(height: 16),
       Container(
         padding: const EdgeInsets.all(16),
         decoration: BoxDecoration(
-          color: Colors.grey[50],
+          color: scheme.surfaceContainerHighest,
           borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: Colors.grey[200]!),
+          border: Border.all(color: scheme.outlineVariant),
         ),
-        child: Column(children: children),
+        child: DefaultTextStyle.merge(
+          style: TextStyle(
+            color: scheme.onSurface,
+            fontSize: 14,
+          ),
+          child: IconTheme.merge(
+            data: IconThemeData(color: scheme.onSurface),
+            child: Column(children: children),
+          ),
+        ),
       ),
     ],
   );
@@ -2910,7 +3011,10 @@ Widget _buildRow(String label, Widget stepper) {
     mainAxisAlignment: MainAxisAlignment.spaceBetween,
     children: [
       Flexible(
-        child: Text(label, style: const TextStyle(fontSize: 14)),
+        child: Text(
+          label,
+          style: const TextStyle(fontSize: 14),
+        ),
       ),
       stepper,
     ],

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.1.1"
   async:
     dependency: transitive
     description:
@@ -28,10 +28,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -126,26 +126,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -203,10 +203,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:
@@ -224,5 +224,5 @@ packages:
     source: hosted
     version: "15.0.2"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/src/_cart_stepper_builders.dart
+++ b/lib/src/_cart_stepper_builders.dart
@@ -487,9 +487,7 @@ mixin _CartStepperBuildersMixin<T extends num>
           );
 
     final quantityDisplay = Expanded(
-      child: Center(
-        child: _buildQuantityDisplay(qty, fontSize),
-      ),
+      child: _buildQuantityDisplay(qty, fontSize),
     );
 
     if (widget.direction == CartStepperDirection.vertical) {
@@ -531,23 +529,32 @@ mixin _CartStepperBuildersMixin<T extends num>
     // stepper's rounded edge; the full tapSize stays hittable.
     final circleSize = math.min(tapSize, widget.size.height - 8);
 
-    return SizedBox(
-      width: tapSize,
-      height: tapSize,
-      child: Center(
-        child: SizedBox(
-          width: circleSize,
-          height: circleSize,
-          child: Material(
-            color: backgroundColor ?? Colors.transparent,
-            shape: const CircleBorder(),
-            clipBehavior: Clip.antiAlias,
-            child: InkWell(
-              onTap: onTap,
-              splashColor: _splColor,
-              highlightColor: _hlColor,
-              child: Center(
-                child: Icon(icon, size: iconSize, color: iconColor),
+    // TextFieldTapRegion keeps these buttons in the TextField's tap group so a
+    // press does not count as "tap outside". Without this, iOS dismisses the
+    // keyboard on the first press and never delivers the confirm/cancel tap.
+    return TextFieldTapRegion(
+      child: SizedBox(
+        width: tapSize,
+        height: tapSize,
+        child: Center(
+          child: SizedBox(
+            width: circleSize,
+            height: circleSize,
+            child: Material(
+              color: backgroundColor ?? Colors.transparent,
+              shape: const CircleBorder(),
+              clipBehavior: Clip.antiAlias,
+              child: InkWell(
+                // Capture on pointer-down so we win the race against focus-loss
+                // handlers if the platform still unfocuses the field.
+                onTapDown: (_) => _beginEditAction(),
+                onTap: onTap,
+                onTapCancel: _endEditAction,
+                splashColor: _splColor,
+                highlightColor: _hlColor,
+                child: Center(
+                  child: Icon(icon, size: iconSize, color: iconColor),
+                ),
               ),
             ),
           ),
@@ -561,19 +568,21 @@ mixin _CartStepperBuildersMixin<T extends num>
   // ============================================================================
   Widget _buildQuantityDisplay(num qty, double fontSize) {
     if (_isLoading && !widget.optimisticUpdate) {
-      return _buildLoadingIndicator();
+      return Center(child: _buildLoadingIndicator());
     }
 
     if (_isEditingManually && widget.enableManualInput) {
       if (widget.manualInputBuilder != null) {
-        return widget.manualInputBuilder!(
-          context,
-          qty,
-          _submitManualInput,
-          _cancelManualInput,
+        return Center(
+          child: widget.manualInputBuilder!(
+            context,
+            qty,
+            _submitManualInput,
+            _cancelManualInput,
+          ),
         );
       }
-      return _buildManualInputField(fontSize);
+      return Center(child: _buildManualInputField(fontSize));
     }
 
     final textStyle = TextStyle(
@@ -590,17 +599,21 @@ mixin _CartStepperBuildersMixin<T extends num>
       formatter: widget.quantityFormatter,
     );
 
-    // Tappable but undecorated — the stepper switches to its inline editor on
-    // tap, so the number needs no extra affordance chrome.
+    // Fill the Expanded middle slot so the whole gap between −/+ is tappable,
+    // not just the digit glyphs (those are easy to miss on a phone).
     if (widget.enableManualInput && widget.enabled && !_isLoading) {
-      return GestureDetector(
-        onTap: _startManualInput,
-        behavior: HitTestBehavior.opaque,
-        child: counter,
+      return Material(
+        type: MaterialType.transparency,
+        child: InkWell(
+          onTap: _startManualInput,
+          splashColor: _splColor,
+          highlightColor: _hlColor,
+          child: Center(child: counter),
+        ),
       );
     }
 
-    return counter;
+    return Center(child: counter);
   }
 
   // ============================================================================
@@ -644,6 +657,9 @@ mixin _CartStepperBuildersMixin<T extends num>
         onSubmitted: _submitManualInput,
         onTapOutside: (_) {
           if (!_isEditingManually) return;
+          // Confirm/cancel are in the same TextFieldTapRegion group, so this
+          // only runs for true outside taps — not the edit action buttons.
+          if (_editActionInProgress) return;
           // Tapping away either commits the value or discards it, but either
           // way it must leave edit mode — otherwise the stepper stays stuck
           // showing a text field.

--- a/lib/src/_cart_stepper_core.dart
+++ b/lib/src/_cart_stepper_core.dart
@@ -232,6 +232,9 @@ abstract class _CartStepperStateBase<T extends num>
   // ============================================================================
   bool _isEditingManually = false;
   bool _isSubmittingManualInput = false;
+  /// True while a confirm/cancel pointer is in progress, so focus-loss must
+  /// not auto-submit/cancel and steal the button's action (common on iOS).
+  bool _editActionInProgress = false;
   TextEditingController? _manualInputController;
   FocusNode? _manualInputFocusNode;
 

--- a/lib/src/_cart_stepper_operations.dart
+++ b/lib/src/_cart_stepper_operations.dart
@@ -42,6 +42,7 @@ mixin _CartStepperOperationsMixin<T extends num> on _CartStepperStateBase<T> {
     if (!_isEditingManually) return;
     _isEditingManually = false;
     _isSubmittingManualInput = false;
+    _editActionInProgress = false;
     _manualInputFocusNode?.unfocus();
   }
 
@@ -97,8 +98,19 @@ mixin _CartStepperOperationsMixin<T extends num> on _CartStepperStateBase<T> {
     });
   }
 
+  void _beginEditAction() {
+    _editActionInProgress = true;
+  }
+
+  void _endEditAction() {
+    _editActionInProgress = false;
+  }
+
   void _submitManualInput(String value) {
-    if (!_isEditingManually || _isSubmittingManualInput) return;
+    if (!_isEditingManually || _isSubmittingManualInput) {
+      _endEditAction();
+      return;
+    }
     _isSubmittingManualInput = true;
 
     final currentQty = _displayQuantity;
@@ -111,6 +123,8 @@ mixin _CartStepperOperationsMixin<T extends num> on _CartStepperStateBase<T> {
     setState(() {
       _isEditingManually = false;
     });
+    _manualInputFocusNode?.unfocus();
+    _endEditAction();
 
     if (clampedValue != currentQty) {
       if (!_validateChange(currentQty, clampedValue)) {
@@ -158,15 +172,22 @@ mixin _CartStepperOperationsMixin<T extends num> on _CartStepperStateBase<T> {
   }
 
   void _cancelManualInput() {
-    if (!_isEditingManually) return;
+    if (!_isEditingManually) {
+      _endEditAction();
+      return;
+    }
     setState(() {
       _isEditingManually = false;
     });
+    _manualInputFocusNode?.unfocus();
+    _endEditAction();
     _resetCollapseTimer();
   }
 
   void _onManualInputFocusChange() {
     if (!mounted) return;
+    // Confirm/cancel buttons own the commit; ignore the focus loss they cause.
+    if (_editActionInProgress) return;
     if (!widget.manualInputConfig.submitOnFocusLost) return;
     if (_manualInputFocusNode != null &&
         !_manualInputFocusNode!.hasFocus &&

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: advance_cart_stepper
 description: "A customizable expandable cart quantity stepper widget for Flutter with async support, loading indicators, and theming."
-version: 2.1.0
+version: 2.1.1
 homepage: https://github.com/khaledsmq/advance_cart_stepper
 repository: https://github.com/khaledsmq/advance_cart_stepper
 issue_tracker: https://github.com/khaledsmq/advance_cart_stepper/issues

--- a/test/cart_stepper_test.dart
+++ b/test/cart_stepper_test.dart
@@ -1598,6 +1598,45 @@ void main() {
       expect(find.byType(TextField), findsOneWidget);
     });
 
+    testWidgets('tapping beside the digit still opens manual input',
+        (WidgetTester tester) async {
+      int quantity = 5;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: AsyncCartStepper(
+                quantity: quantity,
+                collapseConfig: const CartStepperCollapseConfig(
+                  initiallyExpanded: true,
+                ),
+                manualInputConfig: const CartStepperManualInputConfig(
+                  enabled: true,
+                ),
+                onQuantityChanged: (newQty) {
+                  quantity = newQty;
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Tap the gap between − and the digit — previously missed because only
+      // the glyph bounds were hittable.
+      final textCenter = tester.getCenter(find.text('5'));
+      final removeCenter = tester.getCenter(find.byIcon(Icons.remove));
+      await tester.tapAt(
+        Offset((textCenter.dx + removeCenter.dx) / 2, textCenter.dy),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TextField), findsOneWidget);
+    });
+
     testWidgets('manual input submits on enter',
         (WidgetTester tester) async {
       int quantity = 5;
@@ -1681,6 +1720,97 @@ void main() {
 
       // Should be clamped to max
       expect(quantity, equals(10));
+    });
+
+    testWidgets('confirm button commits typed quantity',
+        (WidgetTester tester) async {
+      int quantity = 5;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: StatefulBuilder(
+              builder: (context, setState) {
+                return AsyncCartStepper(
+                  quantity: quantity,
+                  collapseConfig: const CartStepperCollapseConfig(
+                    initiallyExpanded: true,
+                  ),
+                  manualInputConfig: const CartStepperManualInputConfig(
+                    enabled: true,
+                  ),
+                  maxQuantity: 100,
+                  onQuantityChanged: (newQty) {
+                    setState(() => quantity = newQty);
+                  },
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('5'));
+      await tester.pumpAndSettle();
+      expect(find.byType(TextField), findsOneWidget);
+
+      await tester.enterText(find.byType(TextField), '12');
+      await tester.pump();
+
+      // Confirm (✓) should commit even while the field still has focus —
+      // the regression this guards against is iOS eating that tap to dismiss
+      // the keyboard without applying the value.
+      await tester.tap(find.byIcon(Icons.check));
+      await tester.pumpAndSettle();
+
+      expect(quantity, equals(12));
+      expect(find.byType(TextField), findsNothing);
+    });
+
+    testWidgets('cancel button discards typed quantity',
+        (WidgetTester tester) async {
+      int quantity = 5;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: StatefulBuilder(
+              builder: (context, setState) {
+                return AsyncCartStepper(
+                  quantity: quantity,
+                  collapseConfig: const CartStepperCollapseConfig(
+                    initiallyExpanded: true,
+                  ),
+                  manualInputConfig: const CartStepperManualInputConfig(
+                    enabled: true,
+                  ),
+                  maxQuantity: 100,
+                  onQuantityChanged: (newQty) {
+                    setState(() => quantity = newQty);
+                  },
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('5'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '12');
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pumpAndSettle();
+
+      expect(quantity, equals(5));
+      expect(find.byType(TextField), findsNothing);
+      expect(find.text('5'), findsOneWidget);
     });
   });
 


### PR DESCRIPTION
- Fixed iOS confirm/cancel buttons in inline edit mode to apply correctly when the keyboard is open.
- Increased the tap target for quantity adjustments in inline edit mode to improve usability.
- Updated version in pubspec.yaml to 2.1.1.
- Added .gitignore and analysis_options.yaml files to the example project for better development practices.
- Enhanced the main.dart example with improved theming and inline edit functionality.
- Updated tests to cover new inline edit behaviors and confirm/cancel actions.